### PR TITLE
Various changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ or
     }
 ```
 
+By default, all arguments are escaped using
+[escapeshellarg](https://secure.php.net/manual/en/function.escapeshellarg.php).
+If you need to pass unescaped arguments, use `{!name!}`, like so:
+
+```php
+Command::exec('echo {!path!}', ['path' => '$PATH']);
+```
+
 ## Testing
 
 ``` bash

--- a/src/Command.php
+++ b/src/Command.php
@@ -23,7 +23,7 @@ final class Command
     public static function exec($command, array $params = array())
     {
         if (empty($command)) {
-            throw new \Exception('Command line is empty');
+            throw new \InvalidArgumentException('Command line is empty');
         }
 
         $command = self::bindParams($command, $params);
@@ -37,7 +37,7 @@ final class Command
         }
 
         if ($code !== 0) {
-            throw new \Exception($output . ' Command line: ' . $command);
+            throw new CommandException($command, $output, $code);
         }
 
         return $output;

--- a/src/Command.php
+++ b/src/Command.php
@@ -20,13 +20,18 @@ final class Command
      *
      * @throws \Exception
      */
-    public static function exec($command, array $params = array())
+    public static function exec($command, array $params = array(), $mergeStdErr=true)
     {
         if (empty($command)) {
             throw new \InvalidArgumentException('Command line is empty');
         }
 
         $command = self::bindParams($command, $params);
+
+        if ($mergeStdErr) {
+            // Redirect stderr to stdout to include it in $output
+            $command .= ' 2>&1';
+        }
 
         exec($command, $output, $code);
 

--- a/src/CommandException.php
+++ b/src/CommandException.php
@@ -1,0 +1,39 @@
+<?php
+namespace pastuhov\Command;
+
+class CommandException extends \RuntimeException
+{
+    protected $command;
+    protected $output;
+    protected $returnCode;
+
+    public function __construct($command, $output, $returnCode)
+    {
+        $this->command = $command;
+        $this->output = $output;
+        $this->returnCode = $returnCode;
+
+        if ($this->returnCode == 127) {
+            $message = 'Command not found: "' . $this->getCommand() . '"';
+        } else {
+            $message = 'Command "' . $this->getCommand() . '" exited with code ' . $this->getReturnCode() . ': ' . $this->getOutput();
+        }
+
+        parent::__construct($message);
+    }
+
+    public function getCommand()
+    {
+        return $this->command;
+    }
+
+    public function getOutput()
+    {
+        return $this->output;
+    }
+
+    public function getReturnCode()
+    {
+        return $this->returnCode;
+    }
+}

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -49,4 +49,34 @@ class CommandTest extends \PHPUnit_Framework_TestCase
             ''
         );
     }
+
+    /**
+     * Test that arguments are escaped by default
+     */
+    public function testArgumentsEscapedByDefault()
+    {
+        $output = Command::exec(
+            'echo {phrase}',
+            [
+                'phrase' => 'hello $PATH',
+            ]
+        );
+
+        $this->assertEquals('hello $PATH', $output);
+    }
+
+    /**
+     * Test that unescaped arguments can be passed
+     */
+    public function testUnescapedArguments()
+    {
+        $output = Command::exec(
+            'echo {!phrase!}',
+            [
+                'phrase' => 'hello $PATH',
+            ]
+        );
+
+        $this->assertRegexp('/\//', $output);
+    }
 }

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -31,7 +31,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
      */
     public function testExecException()
     {
-        $this->setExpectedException('Exception');
+        $this->setExpectedException('pastuhov\Command\CommandException');
 
         $output = Command::exec(
             'echo111'
@@ -43,7 +43,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
      */
     public function testExecEmptyCommand()
     {
-        $this->setExpectedException('Exception');
+        $this->setExpectedException('InvalidArgumentException');
 
         $output = Command::exec(
             ''


### PR DESCRIPTION
- Use escapeshellarg by default, but allow disabling it.
- Use custom exceptions: `InvalidArgumentException` for the invalid argument case, and
  introduce a new `CommandException` class for the rest.
- Merge stderr with stdout by default (to avoid stderr leaking out like "sh: 1: echo111: not found" does here: https://travis-ci.org/pastuhov/php-exec-command/jobs/152053935)
